### PR TITLE
Twin Flame Pickaxe QOL change

### DIFF
--- a/src/main/java/dev/jsinco/luma/lumaitems/items/tools/TwinFlamePickaxe.kt
+++ b/src/main/java/dev/jsinco/luma/lumaitems/items/tools/TwinFlamePickaxe.kt
@@ -3,6 +3,7 @@ package dev.jsinco.luma.lumaitems.items.tools
 import dev.jsinco.luma.lumaitems.items.ItemFactory
 import dev.jsinco.luma.lumaitems.manager.CustomItemFunctions
 import dev.jsinco.luma.lumaitems.util.tiers.Tier
+import net.kyori.adventure.text.format.TextColor
 import org.bukkit.Material
 import org.bukkit.NamespacedKey
 import org.bukkit.enchantments.Enchantment
@@ -48,9 +49,11 @@ class TwinFlamePickaxe : CustomItemFunctions() {
         if (meta.hasEnchant(Enchantment.FORTUNE)) {
             meta.removeEnchant(Enchantment.FORTUNE)
             meta.addEnchant(Enchantment.SILK_TOUCH, 1, true)
+            player.sendActionBar(net.kyori.adventure.text.Component.text("Switched to Silk Touch").color(TextColor.fromHexString("#FF6AA8")))
         } else if (meta.hasEnchant(Enchantment.SILK_TOUCH)) {
             meta.removeEnchant(Enchantment.SILK_TOUCH)
             meta.addEnchant(Enchantment.FORTUNE, 5, true)
+            player.sendActionBar(net.kyori.adventure.text.Component.text("Switched to Fortune").color(TextColor.fromHexString("#FF6AA8")))
         }
         item.itemMeta = meta
         event.isCancelled = true

--- a/src/main/java/dev/jsinco/luma/lumaitems/items/tools/TwinFlamePickaxe.kt
+++ b/src/main/java/dev/jsinco/luma/lumaitems/items/tools/TwinFlamePickaxe.kt
@@ -2,6 +2,7 @@ package dev.jsinco.luma.lumaitems.items.tools
 
 import dev.jsinco.luma.lumaitems.items.ItemFactory
 import dev.jsinco.luma.lumaitems.manager.CustomItemFunctions
+import dev.jsinco.luma.lumaitems.util.MiniMessageUtil
 import dev.jsinco.luma.lumaitems.util.tiers.Tier
 import net.kyori.adventure.text.format.TextColor
 import org.bukkit.Material
@@ -49,11 +50,11 @@ class TwinFlamePickaxe : CustomItemFunctions() {
         if (meta.hasEnchant(Enchantment.FORTUNE)) {
             meta.removeEnchant(Enchantment.FORTUNE)
             meta.addEnchant(Enchantment.SILK_TOUCH, 1, true)
-            player.sendActionBar(net.kyori.adventure.text.Component.text("Switched to Silk Touch").color(TextColor.fromHexString("#FF6AA8")))
+            player.sendActionBar(MiniMessageUtil.mm("<#FF6AA8>Switched to Silk Touch"))
         } else if (meta.hasEnchant(Enchantment.SILK_TOUCH)) {
             meta.removeEnchant(Enchantment.SILK_TOUCH)
             meta.addEnchant(Enchantment.FORTUNE, 5, true)
-            player.sendActionBar(net.kyori.adventure.text.Component.text("Switched to Fortune").color(TextColor.fromHexString("#FF6AA8")))
+            player.sendActionBar(MiniMessageUtil.mm("<#FF6AA8>Switched to Fortune"))
         }
         item.itemMeta = meta
         event.isCancelled = true


### PR DESCRIPTION
When switching between Silk Touch and Fortune, inform players about the new state by sending them a stylish action bar message. I want to stop checking it's enchantments after each swap, pls accept this